### PR TITLE
Gitignore the generated pkg/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules
 /bin
+/pkg


### PR DESCRIPTION
relates to https://github.com/fastly/ExecuteD/pull/606

We thought it'd be good to not include the generated wasm archive for built C@E apps. Let me know what you think :smile: :+1: 

cc @jhatala 