### PR TITLE
Updated the starter kit for @fastly/as-compute 0.2.0

### DIFF
--- a/assembly/index.ts
+++ b/assembly/index.ts
@@ -17,11 +17,11 @@ const OTHER_BACKEND_NAME = "other_backend_name";
 // synthetic responses.
 function main(req: Request): Response {
     // Make any desired changes to the client request.
-    req.headers().set("Host", "example.com");
+    req.headers.set("Host", "example.com");
 
     // We can filter requests that have unexpected methods.
     const VALID_METHODS = ["HEAD", "GET", "POST"];
-    if (!VALID_METHODS.includes(req.method())) {
+    if (!VALID_METHODS.includes(req.method)) {
         return new Response(String.UTF8.encode("This method is not allowed"), {
             status: 405,
             headers: null,
@@ -29,8 +29,8 @@ function main(req: Request): Response {
         });
     }
 
-    let method = req.method();
-    let urlParts = req.url().split("//").pop().split("/");
+    let method = req.method;
+    let urlParts = req.url.split("//").pop().split("/");
     let host = urlParts.shift();
     let path = "/" + urlParts.join("/");
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,32 +5,32 @@
   "requires": true,
   "dependencies": {
     "@fastly/as-compute": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@fastly/as-compute/-/as-compute-0.1.1.tgz",
-      "integrity": "sha512-kuDYPQjY1o/v9HUEBkAwFYjeui6HCctj7vNGrl06r5ub5p1V8mkd6pqMn5muf6quQLmHkZZZLtKI+vLfYr9Ksw==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@fastly/as-compute/-/as-compute-0.2.0.tgz",
+      "integrity": "sha512-uM7LSwsdlQr3UWuElbQLeCv15djBbxKuuega8fhjorlWnsGbtdggldOiAlDoMK5zp7ZasLK66ctxTMv8sTLx/w==",
       "requires": {
-        "@fastly/as-fetch": "0.1.0"
+        "@fastly/as-fetch": "0.2.0"
       }
     },
     "@fastly/as-fetch": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@fastly/as-fetch/-/as-fetch-0.1.0.tgz",
-      "integrity": "sha512-CIsC8qDx0jZDcMWKxFz/IKyOdeFcvle/mnK6waZQkmeZIKAdSUuZ0AgJxT+AN2Qb5DGhtrYlkJgxkmNnSumpdA=="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@fastly/as-fetch/-/as-fetch-0.2.0.tgz",
+      "integrity": "sha512-BWJRaQSRAmt5TUO2mM51m7rK9DclgZqiJbxC5zms8hyS0bxFYR2AnDoVziJ3Slp5RpoxKedik1xm8hg7RyfaYg=="
     },
     "assemblyscript": {
-      "version": "0.14.13",
-      "resolved": "https://registry.npmjs.org/assemblyscript/-/assemblyscript-0.14.13.tgz",
-      "integrity": "sha512-hV/2Zolfkzn55LrKymdsHLftkf8TXGf/ZDUooN10L9r1Zgf6yOIyIf/bgGq3A2l5lmUt669gk/Uwx2G0KCbCug==",
+      "version": "0.17.14",
+      "resolved": "https://registry.npmjs.org/assemblyscript/-/assemblyscript-0.17.14.tgz",
+      "integrity": "sha512-TLuwNvZAIH26wu2puKpAJokzLp10kJkVXxbgDjFFmbW9VF/qg7rkmi0hjsiu41bjoH1UaVgY4vYvbbUeOHtKyg==",
       "dev": true,
       "requires": {
-        "binaryen": "97.0.0-nightly.20200929",
+        "binaryen": "98.0.0-nightly.20201109",
         "long": "^4.0.0"
       }
     },
     "binaryen": {
-      "version": "97.0.0-nightly.20200929",
-      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-97.0.0-nightly.20200929.tgz",
-      "integrity": "sha512-HQ7VTISqwfVOylWJAE2jIyhuO5zrxTD2Vvc0cwtXTUqfmlbZdt/Z0vxUZD+uFYHRLM0p9ddJc7RPVGsvPI2oEQ==",
+      "version": "98.0.0-nightly.20201109",
+      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-98.0.0-nightly.20201109.tgz",
+      "integrity": "sha512-iRarAqdH5lMWlMBzrDuJgLYJR2g4QXk93iYE2zpr6gEZkb/jCgDpPUXdhuN11Ge1zZ/6By4DwA1mmifcx7FWaw==",
       "dev": true
     },
     "long": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "homepage": "https://github.com/fastly/compute-starter-kit-assemblyscript-default#readme",
   "devDependencies": {
-    "assemblyscript": "^0.14.11"
+    "assemblyscript": "^0.17.13"
   },
   "dependencies": {
     "@fastly/as-compute": "^0.2.0"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "assemblyscript": "^0.14.11"
   },
   "dependencies": {
-    "@fastly/as-compute": "^0.1.1"
+    "@fastly/as-compute": "^0.2.0"
   },
   "scripts": {
     "asbuild:untouched": "asc assembly/index.ts --target debug",


### PR DESCRIPTION
This updates the starter kit to work with the next update for `@fastly/as-compute`, which has some breaking changes, that better match the [Fetch API, for example the Request Object should have properties, and not functions](https://developer.mozilla.org/en-US/docs/Web/API/Request). :smile: 

It also updates the `package.json`, with all the most recent versions of AssemblyScript and `@fastly/as-compute`.

![Screenshot from 2021-01-07 12-07-14](https://user-images.githubusercontent.com/1448289/103939770-21ced980-50e1-11eb-8312-68516179edaf.png)
