### PR TITLE
Updated Starter kit for @fastly/as-compute@0.2.1

### DIFF
--- a/assembly/index.ts
+++ b/assembly/index.ts
@@ -1,4 +1,4 @@
-import { Request,  Response, Headers, Fastly } from "@fastly/as-compute";
+import { Request,  Response, Headers, URL, Fastly } from "@fastly/as-compute";
 
 // The name of a backend server associated with this service.
 //
@@ -30,12 +30,10 @@ function main(req: Request): Response {
     }
 
     let method = req.method;
-    let urlParts = req.url.split("//").pop().split("/");
-    let host = urlParts.shift();
-    let path = "/" + urlParts.join("/");
+    let url = new URL(req.url);
 
     // If request is a `GET` to the `/` path, send a default response.
-    if (method == "GET" && path == "/") {
+    if (method == "GET" && url.pathname == "/") {
         let headers = new Headers();
         headers.set('Content-Type', 'text/html; charset=utf-8');
         return new Response(String.UTF8.encode("<iframe src='https://developer.fastly.com/compute-welcome' style='border:0; position: absolute; top: 0; left: 0; width: 100%; height: 100%'></iframe>\n"), {
@@ -45,7 +43,7 @@ function main(req: Request): Response {
     }
 
     // If request is a `GET` to the `/backend` path, send to a named backend.
-    if (method == "GET" && path == "/backend") {
+    if (method == "GET" && url.pathname == "/backend") {
         // Request handling logic could go here...
         // E.g., send the request to an origin backend and then cache the
         // response for one minute.
@@ -58,7 +56,7 @@ function main(req: Request): Response {
     }
 
     // If request is a `GET` to a path starting with `/other/`.
-    if (method == "GET" && path.startsWith("/other/")) {
+    if (method == "GET" && url.pathname.startsWith("/other/")) {
         // Send request to a different backend and don't cache response.
         let cacheOverride = new Fastly.CacheOverride();
         cacheOverride.setPass();

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,17 +5,24 @@
   "requires": true,
   "dependencies": {
     "@fastly/as-compute": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@fastly/as-compute/-/as-compute-0.2.0.tgz",
-      "integrity": "sha512-uM7LSwsdlQr3UWuElbQLeCv15djBbxKuuega8fhjorlWnsGbtdggldOiAlDoMK5zp7ZasLK66ctxTMv8sTLx/w==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@fastly/as-compute/-/as-compute-0.2.1.tgz",
+      "integrity": "sha512-Aluwes+hY82/D4/4W7QRh+sBc/g9HbMuw+j9gZFS8ypnMGOyGL/3Td41vNl5CvwG1KqhnQeBU35Ackx3Qk/ACA==",
       "requires": {
-        "@fastly/as-fetch": "0.2.0"
+        "@fastly/as-fetch": "0.2.0",
+        "@fastly/as-url": "0.1.0",
+        "assemblyscript-json": "^1.0.0"
       }
     },
     "@fastly/as-fetch": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@fastly/as-fetch/-/as-fetch-0.2.0.tgz",
       "integrity": "sha512-BWJRaQSRAmt5TUO2mM51m7rK9DclgZqiJbxC5zms8hyS0bxFYR2AnDoVziJ3Slp5RpoxKedik1xm8hg7RyfaYg=="
+    },
+    "@fastly/as-url": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@fastly/as-url/-/as-url-0.1.0.tgz",
+      "integrity": "sha512-30bzEHFVv7S1OXrDFcySDTnaka2xXgVsnX7jif0NaxTSCjJJParOf6wWjbGTEYS9qq07lbK2ZdEKJJd+ARVTdQ=="
     },
     "assemblyscript": {
       "version": "0.17.14",
@@ -26,6 +33,11 @@
         "binaryen": "98.0.0-nightly.20201109",
         "long": "^4.0.0"
       }
+    },
+    "assemblyscript-json": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assemblyscript-json/-/assemblyscript-json-1.0.0.tgz",
+      "integrity": "sha512-Cv96RESaVbCJn6jqVPXJlrClb3ZoLwcoSNFPDpHMXxi7NqLBeUGhV6zitSjLIgPHXVocIuYYH+SnykzEtErrBg=="
     },
     "binaryen": {
       "version": "98.0.0-nightly.20201109",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "assemblyscript": "^0.17.13"
   },
   "dependencies": {
-    "@fastly/as-compute": "^0.2.0"
+    "@fastly/as-compute": "^0.2.1"
   },
   "scripts": {
     "asbuild:untouched": "asc assembly/index.ts --target debug",


### PR DESCRIPTION
With the recent release of `@fastly/as-compute@0.2.1`, I went ahead and updated the starter kit to support this. As well as, used the new exported `URL` value, from `@fastly/as-url`, to remove the URL handling cruft :smile: 

**NOTE:** Before we merge this, we probably will want to wait until a matching PR is opened on the Devhub for the new docs . I'll update this when that PR is opened by me :smile: 