### PR TITLE
Updated Starter kit for @fastly/as-compute@0.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,36 +1,105 @@
 {
   "name": "compute-starter-kit-assemblyscript-default",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@fastly/as-compute": "^0.3.0"
+      },
+      "devDependencies": {
+        "assemblyscript": "^0.18.12"
+      }
+    },
+    "node_modules/@fastly/as-compute": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@fastly/as-compute/-/as-compute-0.3.0.tgz",
+      "integrity": "sha512-0XyKfi5vSMV1jeZ0SSYyJO9Y/SfoY6rQKQAbg+QK9Ehsh0lxiyyl7NIyiAYKLP6ywhtyb67YQ6fcsOKOrXBO2w==",
+      "dependencies": {
+        "@fastly/as-fetch": "0.3.0",
+        "@fastly/as-url": "0.1.1",
+        "assemblyscript-json": "^1.0.0"
+      },
+      "peerDependencies": {
+        "assemblyscript": "0.18.x"
+      }
+    },
+    "node_modules/@fastly/as-fetch": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@fastly/as-fetch/-/as-fetch-0.3.0.tgz",
+      "integrity": "sha512-KjbexwxCAuk3W8ZMwy+zrTQ3/alLXA4Dd486VAW/zuS4BguWv205iEu8f5Hc+e87AjJSz1kkL9H4Ope/RZFYeQ=="
+    },
+    "node_modules/@fastly/as-url": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@fastly/as-url/-/as-url-0.1.1.tgz",
+      "integrity": "sha512-wB68lHDjjiSSeCQgUlsoMRUwmVqTGOBJHzgJ2f73LuU1j/kcSzDf6+m9sxddsBVrZJaDAqrbAfcRZikYtGIRMw=="
+    },
+    "node_modules/assemblyscript": {
+      "version": "0.18.32",
+      "resolved": "https://registry.npmjs.org/assemblyscript/-/assemblyscript-0.18.32.tgz",
+      "integrity": "sha512-Py6zremwGhO3nSoI/VxyVUzTZfNhTjzNzFDaUdG4JhPJHeG+FzVlEoNCrw4bE5nPc7F+P2DJ8tZQCqIt15ceKw==",
+      "dependencies": {
+        "binaryen": "100.0.0-nightly.20210413",
+        "long": "^4.0.0"
+      },
+      "bin": {
+        "asc": "bin/asc",
+        "asinit": "bin/asinit"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/assemblyscript"
+      }
+    },
+    "node_modules/assemblyscript-json": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assemblyscript-json/-/assemblyscript-json-1.0.0.tgz",
+      "integrity": "sha512-Cv96RESaVbCJn6jqVPXJlrClb3ZoLwcoSNFPDpHMXxi7NqLBeUGhV6zitSjLIgPHXVocIuYYH+SnykzEtErrBg=="
+    },
+    "node_modules/binaryen": {
+      "version": "100.0.0-nightly.20210413",
+      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-100.0.0-nightly.20210413.tgz",
+      "integrity": "sha512-EeGLIxQmJS0xnYl+SH34mNBqVMoixKd9nsE7S7z+CtS9A4eoWn3Qjav+XElgunUgXIHAI5yLnYT2TUGnLX2f1w==",
+      "bin": {
+        "wasm-opt": "bin/wasm-opt"
+      }
+    },
+    "node_modules/long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+    }
+  },
   "dependencies": {
     "@fastly/as-compute": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@fastly/as-compute/-/as-compute-0.2.1.tgz",
-      "integrity": "sha512-Aluwes+hY82/D4/4W7QRh+sBc/g9HbMuw+j9gZFS8ypnMGOyGL/3Td41vNl5CvwG1KqhnQeBU35Ackx3Qk/ACA==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@fastly/as-compute/-/as-compute-0.3.0.tgz",
+      "integrity": "sha512-0XyKfi5vSMV1jeZ0SSYyJO9Y/SfoY6rQKQAbg+QK9Ehsh0lxiyyl7NIyiAYKLP6ywhtyb67YQ6fcsOKOrXBO2w==",
       "requires": {
-        "@fastly/as-fetch": "0.2.0",
-        "@fastly/as-url": "0.1.0",
+        "@fastly/as-fetch": "0.3.0",
+        "@fastly/as-url": "0.1.1",
         "assemblyscript-json": "^1.0.0"
       }
     },
     "@fastly/as-fetch": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@fastly/as-fetch/-/as-fetch-0.2.0.tgz",
-      "integrity": "sha512-BWJRaQSRAmt5TUO2mM51m7rK9DclgZqiJbxC5zms8hyS0bxFYR2AnDoVziJ3Slp5RpoxKedik1xm8hg7RyfaYg=="
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@fastly/as-fetch/-/as-fetch-0.3.0.tgz",
+      "integrity": "sha512-KjbexwxCAuk3W8ZMwy+zrTQ3/alLXA4Dd486VAW/zuS4BguWv205iEu8f5Hc+e87AjJSz1kkL9H4Ope/RZFYeQ=="
     },
     "@fastly/as-url": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@fastly/as-url/-/as-url-0.1.0.tgz",
-      "integrity": "sha512-30bzEHFVv7S1OXrDFcySDTnaka2xXgVsnX7jif0NaxTSCjJJParOf6wWjbGTEYS9qq07lbK2ZdEKJJd+ARVTdQ=="
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@fastly/as-url/-/as-url-0.1.1.tgz",
+      "integrity": "sha512-wB68lHDjjiSSeCQgUlsoMRUwmVqTGOBJHzgJ2f73LuU1j/kcSzDf6+m9sxddsBVrZJaDAqrbAfcRZikYtGIRMw=="
     },
     "assemblyscript": {
-      "version": "0.17.14",
-      "resolved": "https://registry.npmjs.org/assemblyscript/-/assemblyscript-0.17.14.tgz",
-      "integrity": "sha512-TLuwNvZAIH26wu2puKpAJokzLp10kJkVXxbgDjFFmbW9VF/qg7rkmi0hjsiu41bjoH1UaVgY4vYvbbUeOHtKyg==",
-      "dev": true,
+      "version": "0.18.32",
+      "resolved": "https://registry.npmjs.org/assemblyscript/-/assemblyscript-0.18.32.tgz",
+      "integrity": "sha512-Py6zremwGhO3nSoI/VxyVUzTZfNhTjzNzFDaUdG4JhPJHeG+FzVlEoNCrw4bE5nPc7F+P2DJ8tZQCqIt15ceKw==",
       "requires": {
-        "binaryen": "98.0.0-nightly.20201109",
+        "binaryen": "100.0.0-nightly.20210413",
         "long": "^4.0.0"
       }
     },
@@ -40,16 +109,14 @@
       "integrity": "sha512-Cv96RESaVbCJn6jqVPXJlrClb3ZoLwcoSNFPDpHMXxi7NqLBeUGhV6zitSjLIgPHXVocIuYYH+SnykzEtErrBg=="
     },
     "binaryen": {
-      "version": "98.0.0-nightly.20201109",
-      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-98.0.0-nightly.20201109.tgz",
-      "integrity": "sha512-iRarAqdH5lMWlMBzrDuJgLYJR2g4QXk93iYE2zpr6gEZkb/jCgDpPUXdhuN11Ge1zZ/6By4DwA1mmifcx7FWaw==",
-      "dev": true
+      "version": "100.0.0-nightly.20210413",
+      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-100.0.0-nightly.20210413.tgz",
+      "integrity": "sha512-EeGLIxQmJS0xnYl+SH34mNBqVMoixKd9nsE7S7z+CtS9A4eoWn3Qjav+XElgunUgXIHAI5yLnYT2TUGnLX2f1w=="
     },
     "long": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
-      "dev": true
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,10 +15,10 @@
   },
   "homepage": "https://github.com/fastly/compute-starter-kit-assemblyscript-default#readme",
   "devDependencies": {
-    "assemblyscript": "^0.17.13"
+    "assemblyscript": "^0.18.12"
   },
   "dependencies": {
-    "@fastly/as-compute": "^0.2.1"
+    "@fastly/as-compute": "^0.3.0"
   },
   "scripts": {
     "asbuild:untouched": "asc assembly/index.ts --target debug",


### PR DESCRIPTION
relates to #11

With the recent release of @fastly/as-compute@0.3.0, I went ahead and updated the starter kit to support this. As well as, upgrading the Assemblyscript version to 0.18.x, to match the upgrade in `@fastly/as-compute` :smile: 