### PR TITLE
Updated dependencies to @fastly/as-compute@0.4.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@fastly/as-compute": "^0.4.2"
+        "@fastly/as-compute": "^0.4.3"
       },
       "devDependencies": {
         "assemblyscript": "^0.19.18"
@@ -18,12 +18,12 @@
       }
     },
     "node_modules/@fastly/as-compute": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@fastly/as-compute/-/as-compute-0.4.2.tgz",
-      "integrity": "sha512-DdfmmEK1uw184blCuCx9GHMHYylmcU5phweKeK96q6Or0qJP6C94LwI8HB2tMM5meS2X1ZCNqD5rNH7+LvorIA==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@fastly/as-compute/-/as-compute-0.4.3.tgz",
+      "integrity": "sha512-XCQguMvDIfliy3Drjk1READYgc4omtTuI6aRyvtLFQ2LGxsCDEA2gg5DJgsc1hIYY81WhKXTr3SlfWgMswZ2ew==",
       "dependencies": {
         "@fastly/as-fetch": "0.4.0",
-        "@fastly/as-url": "0.1.1",
+        "@fastly/as-url": "0.1.2",
         "assemblyscript-json": "^1.0.0"
       },
       "peerDependencies": {
@@ -36,9 +36,9 @@
       "integrity": "sha512-vhmO6jjab98SVPEIGLNiAyKnKCoqIHsRPQ5PautilYQI1xu0iOwlheYrI2g88dUmFyaJjFzZPRy8YgP0NQf3vA=="
     },
     "node_modules/@fastly/as-url": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@fastly/as-url/-/as-url-0.1.1.tgz",
-      "integrity": "sha512-wB68lHDjjiSSeCQgUlsoMRUwmVqTGOBJHzgJ2f73LuU1j/kcSzDf6+m9sxddsBVrZJaDAqrbAfcRZikYtGIRMw=="
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@fastly/as-url/-/as-url-0.1.2.tgz",
+      "integrity": "sha512-qAEm06yZka7Px3YRfZ0ZNXo+nicjC94gPf6cquqpuWPwBTxGpK3HRvX1ZNZijBtqoWxWRrTZZ1ZIkoKWOPuYRg=="
     },
     "node_modules/assemblyscript": {
       "version": "0.19.22",
@@ -101,12 +101,12 @@
   },
   "dependencies": {
     "@fastly/as-compute": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@fastly/as-compute/-/as-compute-0.4.2.tgz",
-      "integrity": "sha512-DdfmmEK1uw184blCuCx9GHMHYylmcU5phweKeK96q6Or0qJP6C94LwI8HB2tMM5meS2X1ZCNqD5rNH7+LvorIA==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@fastly/as-compute/-/as-compute-0.4.3.tgz",
+      "integrity": "sha512-XCQguMvDIfliy3Drjk1READYgc4omtTuI6aRyvtLFQ2LGxsCDEA2gg5DJgsc1hIYY81WhKXTr3SlfWgMswZ2ew==",
       "requires": {
         "@fastly/as-fetch": "0.4.0",
-        "@fastly/as-url": "0.1.1",
+        "@fastly/as-url": "0.1.2",
         "assemblyscript-json": "^1.0.0"
       }
     },
@@ -116,9 +116,9 @@
       "integrity": "sha512-vhmO6jjab98SVPEIGLNiAyKnKCoqIHsRPQ5PautilYQI1xu0iOwlheYrI2g88dUmFyaJjFzZPRy8YgP0NQf3vA=="
     },
     "@fastly/as-url": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@fastly/as-url/-/as-url-0.1.1.tgz",
-      "integrity": "sha512-wB68lHDjjiSSeCQgUlsoMRUwmVqTGOBJHzgJ2f73LuU1j/kcSzDf6+m9sxddsBVrZJaDAqrbAfcRZikYtGIRMw=="
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@fastly/as-url/-/as-url-0.1.2.tgz",
+      "integrity": "sha512-qAEm06yZka7Px3YRfZ0ZNXo+nicjC94gPf6cquqpuWPwBTxGpK3HRvX1ZNZijBtqoWxWRrTZZ1ZIkoKWOPuYRg=="
     },
     "assemblyscript": {
       "version": "0.19.22",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "assemblyscript": "^0.19.18"
   },
   "dependencies": {
-    "@fastly/as-compute": "^0.4.2"
+    "@fastly/as-compute": "^0.4.3"
   },
   "scripts": {
     "asbuild:untouched": "asc assembly/index.ts --target debug",


### PR DESCRIPTION
similar to #27 

This updates the `@fastly/as-compute` dependency to the latest version: https://www.npmjs.com/package/@fastly/as-compute 😄 🎉 