### PR TITLE
Bumped @fastly/as-compute to latest (0.5.0)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@fastly/as-compute": "^0.4.3"
+        "@fastly/as-compute": "^0.5.0"
       },
       "devDependencies": {
         "assemblyscript": "^0.19.18"
@@ -18,11 +18,11 @@
       }
     },
     "node_modules/@fastly/as-compute": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@fastly/as-compute/-/as-compute-0.4.3.tgz",
-      "integrity": "sha512-XCQguMvDIfliy3Drjk1READYgc4omtTuI6aRyvtLFQ2LGxsCDEA2gg5DJgsc1hIYY81WhKXTr3SlfWgMswZ2ew==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@fastly/as-compute/-/as-compute-0.5.0.tgz",
+      "integrity": "sha512-HMxc+W/j+n8QpsuIyse0m56Nv1Mz7EmMyfloztzgxXyrS8iHE6XTNlPr57qr41KMP2jWbS36L/+k1jJnhgofLA==",
       "dependencies": {
-        "@fastly/as-fetch": "0.4.0",
+        "@fastly/as-fetch": "0.4.1",
         "@fastly/as-url": "0.1.2",
         "assemblyscript-json": "^1.0.0"
       },
@@ -31,9 +31,9 @@
       }
     },
     "node_modules/@fastly/as-fetch": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@fastly/as-fetch/-/as-fetch-0.4.0.tgz",
-      "integrity": "sha512-vhmO6jjab98SVPEIGLNiAyKnKCoqIHsRPQ5PautilYQI1xu0iOwlheYrI2g88dUmFyaJjFzZPRy8YgP0NQf3vA=="
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@fastly/as-fetch/-/as-fetch-0.4.1.tgz",
+      "integrity": "sha512-9RBjm+BSG2ilt9gWsakqXt9PWIu9pVWxSPjMM+Eb7bRS5fhXdDIieSKW5n7u1JfAenylKfSfPU8RKlMQn869Rg=="
     },
     "node_modules/@fastly/as-url": {
       "version": "0.1.2",
@@ -41,9 +41,9 @@
       "integrity": "sha512-qAEm06yZka7Px3YRfZ0ZNXo+nicjC94gPf6cquqpuWPwBTxGpK3HRvX1ZNZijBtqoWxWRrTZZ1ZIkoKWOPuYRg=="
     },
     "node_modules/assemblyscript": {
-      "version": "0.19.22",
-      "resolved": "https://registry.npmjs.org/assemblyscript/-/assemblyscript-0.19.22.tgz",
-      "integrity": "sha512-+Rclbx0+BI3qAe9fjc8XGbSUDaayTtjINnD19I4MmfpT2R43c9YTQERP36676shkPxb1fisDFZeSTL65Da8Q2g==",
+      "version": "0.19.23",
+      "resolved": "https://registry.npmjs.org/assemblyscript/-/assemblyscript-0.19.23.tgz",
+      "integrity": "sha512-fwOQNZVTMga5KRsfY80g7cpOl4PsFQczMwHzdtgoqLXaYhkhavufKb0sB0l3T1DUxpAufA0KNhlbpuuhZUwxMA==",
       "dependencies": {
         "binaryen": "102.0.0-nightly.20211028",
         "long": "^5.2.0",
@@ -101,19 +101,19 @@
   },
   "dependencies": {
     "@fastly/as-compute": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@fastly/as-compute/-/as-compute-0.4.3.tgz",
-      "integrity": "sha512-XCQguMvDIfliy3Drjk1READYgc4omtTuI6aRyvtLFQ2LGxsCDEA2gg5DJgsc1hIYY81WhKXTr3SlfWgMswZ2ew==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@fastly/as-compute/-/as-compute-0.5.0.tgz",
+      "integrity": "sha512-HMxc+W/j+n8QpsuIyse0m56Nv1Mz7EmMyfloztzgxXyrS8iHE6XTNlPr57qr41KMP2jWbS36L/+k1jJnhgofLA==",
       "requires": {
-        "@fastly/as-fetch": "0.4.0",
+        "@fastly/as-fetch": "0.4.1",
         "@fastly/as-url": "0.1.2",
         "assemblyscript-json": "^1.0.0"
       }
     },
     "@fastly/as-fetch": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@fastly/as-fetch/-/as-fetch-0.4.0.tgz",
-      "integrity": "sha512-vhmO6jjab98SVPEIGLNiAyKnKCoqIHsRPQ5PautilYQI1xu0iOwlheYrI2g88dUmFyaJjFzZPRy8YgP0NQf3vA=="
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@fastly/as-fetch/-/as-fetch-0.4.1.tgz",
+      "integrity": "sha512-9RBjm+BSG2ilt9gWsakqXt9PWIu9pVWxSPjMM+Eb7bRS5fhXdDIieSKW5n7u1JfAenylKfSfPU8RKlMQn869Rg=="
     },
     "@fastly/as-url": {
       "version": "0.1.2",
@@ -121,9 +121,9 @@
       "integrity": "sha512-qAEm06yZka7Px3YRfZ0ZNXo+nicjC94gPf6cquqpuWPwBTxGpK3HRvX1ZNZijBtqoWxWRrTZZ1ZIkoKWOPuYRg=="
     },
     "assemblyscript": {
-      "version": "0.19.22",
-      "resolved": "https://registry.npmjs.org/assemblyscript/-/assemblyscript-0.19.22.tgz",
-      "integrity": "sha512-+Rclbx0+BI3qAe9fjc8XGbSUDaayTtjINnD19I4MmfpT2R43c9YTQERP36676shkPxb1fisDFZeSTL65Da8Q2g==",
+      "version": "0.19.23",
+      "resolved": "https://registry.npmjs.org/assemblyscript/-/assemblyscript-0.19.23.tgz",
+      "integrity": "sha512-fwOQNZVTMga5KRsfY80g7cpOl4PsFQczMwHzdtgoqLXaYhkhavufKb0sB0l3T1DUxpAufA0KNhlbpuuhZUwxMA==",
       "requires": {
         "binaryen": "102.0.0-nightly.20211028",
         "long": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "assemblyscript": "^0.19.18"
   },
   "dependencies": {
-    "@fastly/as-compute": "^0.4.3"
+    "@fastly/as-compute": "^0.5.0"
   },
   "scripts": {
     "asbuild:untouched": "asc assembly/index.ts --target debug",


### PR DESCRIPTION
Super small PR! 😄 

Just bumped to the latest [@fastly/as-compute release](https://www.npmjs.com/package/@fastly/as-compute) on npm, which fixes the `Set-Cookie` header issue a customer was having 😄 