### PR TITLE
Filtering requests by method without mentioning purge

### DIFF
--- a/assembly/index.ts
+++ b/assembly/index.ts
@@ -11,7 +11,7 @@ import { Request, Response, Headers, URL, Fastly } from "@fastly/as-compute";
 
 function main(req: Request): Response {
     // Filter requests that have unexpected methods.
-    if (!["HEAD", "GET", "PURGE"].includes(req.method)) {
+    if (["POST", "PUT", "PATCH", "DELETE"].includes(req.method)) {
         return new Response(String.UTF8.encode("This method is not allowed"), {
             status: 405,
             headers: null,


### PR DESCRIPTION
Since we want to allow purge requests but not _encourage_ them, the method for filtering requests is being rewritten so as not to mention purging. The outcome of the method remains functionally the same, with HEAD, GET, and PURGE requests being let through and POST, PUT, PATCH, and DELETE being blocked. 